### PR TITLE
pull public ips from aws-cli and not /latest/meta-data

### DIFF
--- a/lib/aws-eni/version.rb
+++ b/lib/aws-eni/version.rb
@@ -1,5 +1,5 @@
 module Aws
   module ENI
-    VERSION = "0.6.0"
+    VERSION = "0.6.1"
   end
 end


### PR DESCRIPTION
## Issue
At some point in the recent past, the `/latest/meta-data/.../ipv4-associations/{private-ip}` endpoint started bunching up all public IPs to _one_ private IP. In the AWS console, the public IPs were still mapped to the correct private IPs. This bug/feature from the endpoint caused the mappings to break since aws-eni thought that only one private IP had a public IP assigned even though multiple private IPs could have had public IPs associated. 

## Resolution
Instead of hitting `/meta-data/...` endpoints to query for public IPs, this PR will start using `aws ec2 describe-addresses` to fetch the _actual_ private/public IP mappings for a given ENI. 